### PR TITLE
Markupeasy – бесплатный аналог Avocode.

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
 						<li><a target="_blank" href="https://assets.adobe.com/">Adobe Assets</a> – работа с PSD-макетами прямо в браузере. Экспорт кода.</li>
 						<li><a target="_blank" href="https://zeplin.io/">Zeplin</a> – работа с дизайн-макетами в браузере. Есть экспорт кода.</li>
 						<li><a target="_blank" href="https://psdetch.com/">PSD Tech</a> – бесплатный аналог Avocode.</li>
+						<li><a target="_blank" href="https://www.markupeasy.ru/">Markupeasy</a> – бесплатный аналог Avocode.</li>
 					</ol>
 					<h3 class="section-title">Библиотеки с анимациями</h3>
 					<ol class="unstyled-list">


### PR DESCRIPTION
Markupeasy – бесплатный аналог Avocode.